### PR TITLE
fix: tool calls需要显示声明content字段

### DIFF
--- a/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
+++ b/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
@@ -124,6 +124,7 @@ public class LLM {
                     messageMap.put("content", claudeToolCalls);
                 } else {
                     messageMap.put("role", message.getRole().getValue());
+                    messageMap.put("content", null);
                     List<Map<String, Object>> toolCallsMap = JSON.parseObject(JSON.toJSONString(message.getToolCalls()),
                             new TypeReference<List<Map<String, Object>>>() {
                             });


### PR DESCRIPTION
标准格式应该是这样：

```json
[
  { "role": "system", "content": "..." },
  
  { "role": "user", "content": "今天资讯" },
  
  {
    "role": "assistant",
    "content": null,  // 可空但必须存在
    "tool_calls": [
      {
        "id": "call_7YbJhIYfRR6ocKiscsUwWQ", 
        "type": "function",
        "function": {
          "name": "get_news_summary",       
          "arguments": "{\"date\":\"2023-11-20\"}" 
        }
      }
    ]
  },
  
  {
    "role": "tool",
    "tool_call_id": "call_7YbJhIYfRR6ocKiscsUwWQ", 
    "content": "{\"summary\": \"今日要闻...\", \"source\": \"新华网\"}"
  },
  
  {
    "role": "assistant",
    "content": "今日资讯摘要已生成，下载链接：http://127.0.0.1:1601/..."
  }
]
```

实测qwen3系列，如果content不显示声明会报`api_error`错误。