### PR TITLE
fix: a bug of `check_dep_port.sh`

### DIFF
--- a/check_dep_port.sh
+++ b/check_dep_port.sh
@@ -19,7 +19,7 @@ if command -v java &> /dev/null; then
     JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2)
     JAVA_MAJOR=$(echo $JAVA_VERSION | cut -d'.' -f1)
     
-    if [[ "$JAVA_VERSION" == *"1."* ]]; then
+    if [[ "$JAVA_VERSION" == "1."* ]]; then
         JAVA_MAJOR=$(echo $JAVA_VERSION | cut -d'.' -f2)
     fi
     


### PR DESCRIPTION
修复一个 bug，使用本地 Java 版本=`21.0.x` 的时候，`check_dep_port.sh` 会报错，因为这里匹配到了 `*1.*`，这时`JAVA_MAJOR= 0`，导致 JAVA_MAJOR>=17 的条件不会通过。把前面的 `*` 去掉就好了。

fix: a bug of check_dep_port.sh, when using Java 21.x.x, the scripts will failed since a wrong Java version matching condition.