### PR TITLE
fix(agent): 修复 LLM 数据解析问题

### DIFF
--- a/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
+++ b/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
@@ -663,8 +663,9 @@ public class LLM {
                                 new InputStreamReader(responseBody.byteStream())
                         );
                         while ((line = reader.readLine()) != null) {
-                            if (line.startsWith("data: ")) {
-                                String data = line.substring(6);
+                            if (line.startsWith("data:")) {
+                                //这里返回的数据格式是 data:{}中间没有空格
+                                String data = line.substring(5);
                                 if (data.equals("[DONE]")) {
                                     break;
                                 }


### PR DESCRIPTION
- 修改了数据行的起始标识，从 "data: " 改为 "data:"- 调整了数据截取的起始位置，从 line.substring(6) 改为 line.substring(5)
- 添加了注释，说明返回的数据格式是 "data:{}" 中间没有空格