### PR TITLE
fix:修复LLM类处理解析ToolCall代码中字符串非空判断

### DIFF
--- a/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
+++ b/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
@@ -700,28 +700,31 @@ public class LLM {
                                             // tool call
                                             if (Objects.nonNull(choice.delta.tool_calls)) {
                                                 List<OpenAIToolCall> openAIToolCalls = choice.delta.tool_calls;
+                                                // 使用循环索引作为工具的Key 未来看看是否需要更改工具缓存的Key
+                                                int curIndex = 0;
                                                 // log.info("{} recv tool call data: {}", context.getRequestId(), openAIToolCalls);
                                                 for (OpenAIToolCall toolCall : openAIToolCalls) {
-                                                    OpenAIToolCall currentToolCall = openToolCallsMap.get(toolCall.index);
+                                                    OpenAIToolCall currentToolCall = openToolCallsMap.get(curIndex);
                                                     if (Objects.isNull(currentToolCall)) {
                                                         currentToolCall = new OpenAIToolCall();
                                                     }
                                                     // [{"index":0,"id":"call_j74R8JMFWTC4rW5wHJ0TtmNU","type":"function","function":{"name":"planning","arguments":""}}]
-                                                    if (Objects.nonNull(toolCall.id)) {
+                                                    if (StringUtil.isNotEmpty(toolCall.id)) {
                                                         currentToolCall.id = toolCall.id;
                                                     }
-                                                    if (Objects.nonNull(toolCall.type)) {
+                                                    if (StringUtil.isNotEmpty(toolCall.type)) {
                                                         currentToolCall.type = toolCall.type;
                                                     }
                                                     if (Objects.nonNull(toolCall.function)) {
-                                                        if (Objects.nonNull(toolCall.function.name)) {
+                                                        if (StringUtil.isNotEmpty(toolCall.function.name)) {
                                                             currentToolCall.function = toolCall.function;
                                                         }
-                                                        if (Objects.nonNull(toolCall.function.arguments)) {
+                                                        if (StringUtil.isNotEmpty(toolCall.function.arguments)) {
                                                             currentToolCall.function.arguments += toolCall.function.arguments;
                                                         }
                                                     }
-                                                    openToolCallsMap.put(toolCall.index, currentToolCall);
+                                                    openToolCallsMap.put(curIndex, currentToolCall);
+                                                    curIndex++;
                                                 }
                                             }
                                         }

--- a/genie-backend/src/main/java/com/jd/genie/agent/util/StringUtil.java
+++ b/genie-backend/src/main/java/com/jd/genie/agent/util/StringUtil.java
@@ -135,6 +135,14 @@ public class StringUtil {
         return uuid.toString();
     }
 
+    public static boolean isEmpty(String str){
+        return str == null || str.trim().isEmpty();
+    }
+    
+    public static boolean isNotEmpty(String str){
+        return !isEmpty(str);
+    }
+
     public static void main(String[] args) {
 
         System.out.println(getUUID());


### PR DESCRIPTION
开源贡献协议已发送邮件。

修复问题原因参考ISSUE:
#134 

1、增加了字符串非空的判断，避免没判断空串导致工具参数被覆盖
2、同时使用循环中的index作为工具缓存Key。因为我看我的GPT4.1模型，没有返回index字段：

`data: {"id":"chatcmpl-ByiFkiqCvZT0nq2IToyfuP9t75gkg","object":"chat.completion.chunk","created":1753809488,"model":"gpt-4.1","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call_GiAC5y7t40D4pTHdrOlhJocz","type":"function","function":{"name":"report_tool","parameters":null,"arguments":""}}]}}]}

data: {"id":"chatcmpl-ByiFkiqCvZT0nq2IToyfuP9t75gkg","object":"chat.completion.chunk","created":1753809488,"model":"gpt-4.1","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"","parameters":null,"arguments":"{\""}}]}}]}`

