### PR TITLE
fix(tool):修复windows下tool字符集默认编码导致file文件乱码、无法读取prompt文件等问题

### DIFF
--- a/genie-tool/genie_tool/db/file_table_op.py
+++ b/genie-tool/genie_tool/db/file_table_op.py
@@ -24,7 +24,7 @@ class _FileDB(object):
         save_path = os.path.join(self._work_dir, scope)
         if not os.path.exists(save_path):
             os.makedirs(save_path)
-        with open(f"{save_path}/{file_name}", "w") as f:
+        with open(f"{save_path}/{file_name}", "w", encoding="utf-8") as f:
             f.write(content)
         return f"{save_path}/{file_name}"
     
@@ -32,7 +32,7 @@ class _FileDB(object):
         file_name = file.filename
         file_data = file.file.read()
         save_path = os.path.join(self._work_dir, file_name)
-        with open(save_path, "wb") as f:
+        with open(save_path, "wb", encoding="utf-8") as f:
              f.write(file_data)
         return save_path
 

--- a/genie-tool/genie_tool/util/prompt_util.py
+++ b/genie-tool/genie_tool/util/prompt_util.py
@@ -11,5 +11,5 @@ import yaml
 
 
 def get_prompt(prompt_file):
-    return yaml.safe_load(importlib.resources.files("genie_tool.prompt").joinpath(f"{prompt_file}.yaml").read_text())
+    return yaml.safe_load(importlib.resources.files("genie_tool.prompt").joinpath(f"{prompt_file}.yaml").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
贡献者协议邮件已发
变更：
1. 文件服务保存时指定编码为utf-8,  解决windows下保存的文件（搜索结果，markdown，html等报告）乱码问题
2. 解决tool读取deepsearch.yaml文件时的编码报错问题