### PR TITLE
删除lock文件，兼容多数平台自编译

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM docker.m.daocloud.io/library/node:20-alpine as frontend-builder
 WORKDIR /app
 RUN npm install -g pnpm
-COPY ui/package.json ui/pnpm-lock.yaml ./
+COPY ui/package.json ./
 RUN npm config set registry https://registry.npmmirror.com
 RUN pnpm install
 COPY ui/ .


### PR DESCRIPTION
pnpm的lock文件虽然能加速下载，但不同平台兼容性太差，容易报错，不如干脆删除掉。