### PR TITLE
修复 Windows 本地环境下文件名非法字符和文件读取乱码问题

### DIFF
--- a/genie-tool/genie_tool/db/file_table_op.py
+++ b/genie-tool/genie_tool/db/file_table_op.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import List
 
 from fastapi import UploadFile
@@ -14,17 +15,19 @@ class _FileDB(object):
         self._work_dir = os.getenv("FILE_SAVE_PATH", "file_db_dir")
         if not os.path.exists(self._work_dir):
             os.makedirs(self._work_dir)
-
+    def _sanitize_filename(self, name: str) -> str:
+        # 替换 Windows 非法字符：<>:"/\|?*
+        return re.sub(r'[<>:"/\\|?*]', '_', name)
     async def save(self, file_name, content, scope) -> str:
         if "." in file_name:
             file_name = os.path.basename(file_name)
         else:
             file_name = f"{file_name}.txt"
-
-        save_path = os.path.join(self._work_dir, scope)
+        safe_scope = self._sanitize_filename(scope or "default")
+        save_path = os.path.join(self._work_dir, safe_scope)
         if not os.path.exists(save_path):
             os.makedirs(save_path)
-        with open(f"{save_path}/{file_name}", "w") as f:
+        with open(f"{save_path}/{file_name}", "w", encoding='utf-8') as f:
             f.write(content)
         return f"{save_path}/{file_name}"
     

--- a/genie-tool/genie_tool/util/prompt_util.py
+++ b/genie-tool/genie_tool/util/prompt_util.py
@@ -11,5 +11,5 @@ import yaml
 
 
 def get_prompt(prompt_file):
-    return yaml.safe_load(importlib.resources.files("genie_tool.prompt").joinpath(f"{prompt_file}.yaml").read_text())
+    return yaml.safe_load(importlib.resources.files("genie_tool.prompt").joinpath(f"{prompt_file}.yaml").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
本次修改针对 Windows 本地环境非 Docker 执行中 出现的两个问题进行了修复：

1️⃣ 文件创建时报错（非法文件名字符问题）
Windows 不支持文件名中包含 <>:"/\|?* 等字符，原逻辑没有处理，导致某些任务在 Windows 本地运行时报 OSError。

本次增加了 _sanitize_filename 方法，自动将非法字符替换为 _，保证文件可以正常创建。

2️⃣ 读取 Prompt 文件时出现乱码
Windows 下 read_text() 默认编码不是 utf-8，导致中文 prompt 文件读取后乱码。

本次统一加上 encoding='utf-8' 显式指定编码，保证跨平台一致性。

影响模块：
file_table_op.py 文件保存逻辑

prompt_util.py Prompt 读取逻辑

目的：
让 genie-tool 工具在 Windows 本地运行时避免一些不必要的报错，不用改动代码即可兼容，文件创建、prompt 加载保持一致性。