### PR TITLE
修复推理地址问题

### DIFF
--- a/genie-backend/src/main/resources/application.yml
+++ b/genie-backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ llm:
   default:
     base_url: '<input llm server here>'
     apikey: '<input llm key here>'
-    interface_url: '/chat/completions'
+    interface_url: '/v1/chat/completions'
     model: gpt-4.1
     max_tokens: 16384
   settings: '{"claude-3-7-sonnet-v1": {


### PR DESCRIPTION
https://github.com/jd-opensource/joyagent-jdgenie/blob/25783436b49e15f0d1896630b4f001e81b454781/genie-backend/src/main/resources/application.yml#L15 该配置自定义的推理地址少了/v1开头导致大模型调用时报404，默认跑起来的时候就会出现这个Issue ：https://github.com/jd-opensource/joyagent-jdgenie/issues/230

```
java.util.concurrent.ExecutionException: java.io.IOException: Unexpected response code: Response{protocol=http/1.1, code=404, message=Not Found, url=http://172.xx.xx.xx:11434/chat/completions}
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[na:na]
	at com.jd.genie.agent.agent.SummaryAgent.summaryTaskResult(SummaryAgent.java:162) ~[genie-backend-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at com.jd.genie.service.impl.ReactHandlerImpl.handle(ReactHandlerImpl.java:34) ~[genie-backend-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at com.jd.genie.controller.GenieController.lambda$AutoAgent$4(GenieController.java:147) ~[genie-backend-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
Caused by: java.io.IOException: Unexpected response code: Response{protocol=http/1.1, code=404, message=Not Found, url=http://172.xx.xx.xxx:11434/chat/completions}
	at com.jd.genie.agent.llm.LLM$4.onResponse(LLM.java:594) ~[genie-backend-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519) ~[okhttp-4.9.3.jar:na]
	... 3 common frames omitted

```