### PR TITLE
fix: 补充web search tool当前检索内容

### DIFF
--- a/genie-tool/genie_tool/tool/deepsearch.py
+++ b/genie-tool/genie_tool/tool/deepsearch.py
@@ -62,11 +62,13 @@ class DeepSearch:
         """深度搜索回复（流式）"""
 
         current_loop = 1
+        current_search = ""
         # 执行深度搜索循环
         while current_loop <= max_loop:
             logger.info(f"{request_id} 第 {current_loop} 轮深度搜索...")
             # 查询分解
-            sub_queries = await query_decompose(query=query)
+            current_search =  "\n".join(self.searched_queries) if self.searched_queries else "" 
+            sub_queries = await query_decompose(query=query, retrieval_str=current_search)
 
             yield json.dumps({
                 "requestId": request_id,

--- a/genie-tool/genie_tool/tool/search_component/query_process.py
+++ b/genie-tool/genie_tool/tool/search_component/query_process.py
@@ -20,6 +20,7 @@ from genie_tool.util.log_util import timer
 @timer()
 async def query_decompose(
         query: str,
+        retrieval_str: str = "",
         **kwargs
 ):
     model = os.getenv("QUERY_DECOMPOSE_MODEL", "gpt-4.1")
@@ -29,7 +30,7 @@ async def query_decompose(
     # think
     think_content = ""
     async for chunk in ask_llm(
-            messages=decompose_prompt["query_decompose_think_prompt"].format(task=query, retrieval_str=""),
+            messages=decompose_prompt["query_decompose_think_prompt"].format(task=query, retrieval_str=retrieval_str),
             model=think_model,
             stream=True,
             only_content=True,  # 只返回内容


### PR DESCRIPTION
- 当web search tool 的深度搜索循环在多轮情况下，问题分解query decompose（负责根据用户query进行thinking的LLM调用）拿不到之前搜索的内容，这个修改添加了当前DeepSearch的所有搜索过的问题searched_queries，并且保证了第一轮深度搜索循环时传入的searched_queries为空