### PR TITLE
fix: Removes merge conflict marker to prevent parsing errors.

### DIFF
--- a/genie-tool/.env_template
+++ b/genie-tool/.env_template
@@ -96,7 +96,7 @@ TR_BGE_RERANK_URL=
 TR_RERANK_TOPK=5
 TR_SCHEMA_TOPK=None
 TR_MODEL_CODE_TOPK=None
-=======
+
 # cal engine 配置
 CAL_ENGINE_MODEL=gpt-4.1
 


### PR DESCRIPTION
## About Issue
When using Dockerfile installation, I found this issue in Docker when starting `start_genie.sh` file. 
``` shell
start_genie.sh: 93: export: : bad variable name
```

This is due to the wrong grammar in `tool/.env_template` file. There is a extra line of wrong.
