### PR TITLE
fix(llm):修复深度思考bug：获取工具类json拼接问题

### DIFF
--- a/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
+++ b/genie-backend/src/main/java/com/jd/genie/agent/llm/LLM.java
@@ -714,10 +714,16 @@ public class LLM {
                                                         currentToolCall.type = toolCall.type;
                                                     }
                                                     if (Objects.nonNull(toolCall.function)) {
+                                                        if (Objects.isNull(currentToolCall.function)) {
+                                                            currentToolCall.function = new OpenAIFunction();
+                                                        }
                                                         if (Objects.nonNull(toolCall.function.name)) {
-                                                            currentToolCall.function = toolCall.function;
+                                                            currentToolCall.function.name = toolCall.function.name;
                                                         }
                                                         if (Objects.nonNull(toolCall.function.arguments)) {
+                                                            if (Objects.isNull(currentToolCall.function.arguments)) {
+                                                                currentToolCall.function.arguments = "";
+                                                            }
                                                             currentToolCall.function.arguments += toolCall.function.arguments;
                                                         }
                                                     }


### PR DESCRIPTION
- 避免直接覆盖 function 对象，造成arguments重复拼接问题
<img width="959" height="510" alt="image" src="https://github.com/user-attachments/assets/8a729a08-f96a-4d26-972f-520df5915712" />
