### PR TITLE
feat: support Apache Doris

### DIFF
--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/catalog/doris/DorisCatalog.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/catalog/doris/DorisCatalog.java
@@ -1,0 +1,88 @@
+
+package com.jd.genie.data.jdbc.catalog.doris;
+
+
+import com.jd.genie.data.SimpleTable;
+import com.jd.genie.data.TableColumn;
+import com.jd.genie.data.exception.CatalogException;
+import com.jd.genie.data.jdbc.catalog.AbstractJdbcCatalog;
+import com.jd.genie.data.model.StandardColumnType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+public class DorisCatalog extends AbstractJdbcCatalog {
+
+    protected static final Set<String> SYS_DATABASES = new HashSet<>(4);
+    private static final String SELECT_COLUMNS_SQL_TEMPLATE =
+            "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA IN  ('%s') AND TABLE_NAME ='%s' ORDER BY ORDINAL_POSITION ASC";
+
+    static {
+        SYS_DATABASES.add("information_schema");
+        SYS_DATABASES.add("mysql");
+        SYS_DATABASES.add("performance_schema");
+        SYS_DATABASES.add("sys");
+    }
+
+    @Override
+    public List<SimpleTable> listTables(Connection connection, String schema) throws CatalogException {
+        String sql = "show tables ";
+        try (PreparedStatement prepared = connection.prepareStatement(sql);
+             ResultSet rs = prepared.executeQuery()) {
+            List<SimpleTable> tables = new ArrayList<>();
+            while (rs.next()) {
+                SimpleTable st = new SimpleTable();
+                st.setTableName(rs.getString(1));
+                tables.add(st);
+            }
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException("获取数据库表失败", e);
+        }
+    }
+
+    public String typeConvertMysql(String type) {
+        return switch (type) {
+            case "DATE", "TIME", "TIMESTAMP" -> StandardColumnType.DATE.name();
+            case "TINYINT", "SMALLINT", "INTEGER", "BIGINT", "FLOAT", "DOUBLE", "NUMERIC", "DECIMAL" ->
+                    StandardColumnType.DECIMAL.name();
+            default -> StandardColumnType.VARCHAR.name();
+        };
+    }
+
+    @Override
+    public List<TableColumn> getTableColumns(Connection connection, String tablePath, String schema) throws CatalogException {
+        String sql = String.format(
+                SELECT_COLUMNS_SQL_TEMPLATE, schema, tablePath);
+
+        try (Statement prepared = connection.createStatement();
+             ResultSet rs = prepared.executeQuery(sql)) {
+            int i = 1;
+            List<TableColumn> columnList = new ArrayList<>();
+            while (rs.next()) {
+                String columnName = rs.getString("COLUMN_NAME");
+                String jdbcDataType = rs.getString("DATA_TYPE").toUpperCase();
+                String dataType = typeConvertMysql(jdbcDataType);
+                String comment = rs.getString("COLUMN_COMMENT");
+                TableColumn column = TableColumn.builder().name(columnName)
+                        .comment(comment)
+                        .dataType(dataType)
+                        .originDataType(jdbcDataType)
+                        .nullable(rs.getBoolean("Is_NULLABLE"))
+                        .position(i++)
+                        .build();
+                columnList.add(column);
+            }
+            return columnList;
+
+        } catch (Exception e) {
+            throw new CatalogException(
+                    String.format("获取表字段信息失败 %s", tablePath), e);
+        }
+    }
+}

--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/catalog/doris/DorisCatalogFactory.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/catalog/doris/DorisCatalogFactory.java
@@ -1,0 +1,20 @@
+package com.jd.genie.data.jdbc.catalog.doris;
+
+import com.google.auto.service.AutoService;
+import com.jd.genie.data.jdbc.catalog.JdbcCatalog;
+import com.jd.genie.data.jdbc.catalog.JdbcCatalogFactory;
+import com.jd.genie.data.jdbc.dialect.DialectEnum;
+
+
+@AutoService(JdbcCatalogFactory.class)
+public class DorisCatalogFactory implements JdbcCatalogFactory {
+    @Override
+    public DialectEnum jdbcDialect() {
+        return DialectEnum.DORIS;
+    }
+
+    @Override
+    public JdbcCatalog createCatalog() {
+        return new DorisCatalog();
+    }
+}

--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/connection/JdbcConnectionPoolFactory.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/connection/JdbcConnectionPoolFactory.java
@@ -36,6 +36,7 @@ public class JdbcConnectionPoolFactory implements Serializable {
         switch (connConfig.getJdbcDialect()) {
             case MYSQL:
             case H2:
+            case DORIS:
             case CLICKHOUSE:
                 datasourceWrapper.setDataSource(createHikariDatasource(connConfig, jdbcDialect));
                 break;

--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/DialectEnum.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/DialectEnum.java
@@ -7,7 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 public enum DialectEnum {
     MYSQL("MySql", "jdbc:mysql://", "/", ""),
     H2("h2", "jdbc:h2:mem", ":", ";MODE=MySQL"),
-    CLICKHOUSE("ClickHouse", "jdbc:clickhouse://", "/", "");
+    CLICKHOUSE("ClickHouse", "jdbc:clickhouse://", "/", ""),
+    DORIS("Doris", "jdbc:mysql://", "/", "");
 
     private final String name;
     private final String urlPrefix;

--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/doris/DorisDialect.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/doris/DorisDialect.java
@@ -1,0 +1,49 @@
+package com.jd.genie.data.jdbc.dialect.doris;
+
+
+
+import com.jd.genie.data.jdbc.dialect.DialectEnum;
+import com.jd.genie.data.jdbc.dialect.mysql.MysqlDialect;
+import com.jd.genie.data.jdbc.dialect.JdbcDialect;
+import java.util.Properties;
+
+public class DorisDialect extends MysqlDialect {
+    
+    @Override
+    public DialectEnum dialectName() {
+        return DialectEnum.DORIS;
+    }
+
+    @Override
+    public String driverName() {
+        return "com.mysql.jdbc.Driver";
+    }
+
+    @Override
+    public Properties defaultProperties() {
+        Properties properties = super.defaultProperties();
+        
+        // 保留MySQL的基础配置
+        properties.setProperty("remarks", "true");
+        properties.setProperty("useInformationSchema", "true");
+        
+        // 添加Doris特有优化
+        properties.setProperty("connectTimeout", "10000");
+        properties.setProperty("socketTimeout", "30000");
+        properties.setProperty("zeroDateTimeBehavior", "convertToNull");
+        
+        // 性能优化
+        properties.setProperty("useServerPrepStmts", "false");
+        properties.setProperty("rewriteBatchedStatements", "true");
+        properties.setProperty("cachePrepStmts", "true");
+        
+        return properties;
+    }
+    @Override
+    public String testSql() {
+        return "SELECT 1";
+    }
+    
+    
+    
+}

--- a/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/doris/DorisDialectFactory.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/jdbc/dialect/doris/DorisDialectFactory.java
@@ -1,0 +1,22 @@
+package com.jd.genie.data.jdbc.dialect.doris;
+
+import com.google.auto.service.AutoService;
+import com.jd.genie.data.jdbc.dialect.DialectEnum;
+import com.jd.genie.data.jdbc.dialect.JdbcDialect;
+import com.jd.genie.data.jdbc.dialect.JdbcDialectFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AutoService(JdbcDialectFactory.class)
+public class DorisDialectFactory implements JdbcDialectFactory {
+    @Override
+    public boolean acceptsURL(String url) {
+        return url.startsWith(DialectEnum.DORIS.getUrlPrefix());
+    }
+
+    @Override
+    public JdbcDialect create() {
+        return new DorisDialect();
+    }
+    
+}

--- a/genie-backend/src/main/java/com/jd/genie/data/sql/SqlParserUtils.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/sql/SqlParserUtils.java
@@ -36,7 +36,7 @@ public class SqlParserUtils {
     private static SqlParser.Config parserConfig(@NonNull String dialectString) {
         DialectEnum dialectEnum = DialectEnum.of(dialectString);
         return switch (dialectEnum) {
-            case H2, MYSQL -> MysqlCustomSqlDialect.DEFAULT.configureParser(SqlParser.config())
+            case H2, MYSQL,DORIS -> MysqlCustomSqlDialect.DEFAULT.configureParser(SqlParser.config())
                     .withConformance(SqlConformanceEnum.MYSQL_5);
             case CLICKHOUSE -> ClickHouseSqlDialect2.DEFAULT.configureParser(SqlParser.config())
                     .withConformance(SqlConformanceEnum.LENIENT);

--- a/genie-backend/src/main/java/com/jd/genie/data/sql/dialect/DorisSqlDialect.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/sql/dialect/DorisSqlDialect.java
@@ -1,0 +1,17 @@
+package com.jd.genie.data.sql.dialect;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.MysqlSqlDialect;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class DorisSqlDialect extends MysqlCustomSqlDialect {
+
+    public static final SqlDialect DEFAULT = new DorisSqlDialect();
+
+    private DorisSqlDialect() {
+        super(DEFAULT_CONTEXT);
+    }
+
+    // Doris 有特殊语法，可以 override 方法
+}
+

--- a/genie-backend/src/main/java/com/jd/genie/data/sql/dialect/SqlDialectUtil.java
+++ b/genie-backend/src/main/java/com/jd/genie/data/sql/dialect/SqlDialectUtil.java
@@ -10,6 +10,7 @@ public class SqlDialectUtil {
         return switch (dialectEnum) {
             case H2,MYSQL -> MysqlCustomSqlDialect.DEFAULT;
             case CLICKHOUSE -> ClickHouseSqlDialect2.DEFAULT;
+            case DORIS -> DorisSqlDialect.DEFAULT;
         };
     }
 }


### PR DESCRIPTION
Apache Doris 是一个广泛应用的 MPP 实时分析型数据库，兼容 MySQL 协议，技术上确实可以通过 type: mysql 连接并查询。
但为了提升用户体验、系统可维护性，并为未来扩展 Doris 特有功能（如 BITMAP_UNION、HLL_CARDINALITY 等）预留能力，显式支持 type: doris 更合理。
如果只用 mysql 类型，系统无法区分底层是否是 Doris，也就难以做针对性优化。所以提前留个口子，对长期演进很有帮助。
本地测试 Doris 2.1.0，基础查询正常 